### PR TITLE
Add more detailed error for wrong email

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -19,3 +19,12 @@ $govuk-assets-path: '/govuk/assets/';
 @import "patterns/task-list";
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you
+
+.govuk-notification-banner {
+    border-color: $govuk-error-colour;
+    background: $govuk-error-colour;
+}
+
+.govuk-notification-banner__header {
+    color: $govuk-error-colour;
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -116,7 +116,7 @@ router.post('/confirm-email/:id', function (req, res) {
     if (!config('emailAddressHashes').includes(hash)) {
         return pageWithConfig(req, res, 'confirm-email.html', {
             emailAddress: emailAddress,
-            errors: 'wrongEmail'
+            wrongEmail: true
         });
     }
 

--- a/app/views/confirm-email.html
+++ b/app/views/confirm-email.html
@@ -31,21 +31,26 @@
 
     {% endif %}
 
-    {% if errors == 'wrongEmail' %}
+    {% if wrongEmail %}
 
-      {{ govukErrorSummary({
-        titleText: "There is a problem",
-        errorList: [
-          {
-            text: "Wrong email address",
-            href: "#email-address"
-          }
-        ]
-      }) }}
-
-      {% set inlineErrorMessage = {
-        text: "Wrong email address"
-      } %}
+      <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Error
+          </h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+          <h3 class="govuk-notification-banner__heading">
+            Enter the email address this link was sent to
+          </h3>
+          <p class="govuk-body">
+            We’re just checking it’s the same email address.
+          </p>
+          <p class="govuk-body">
+            We will not send any extra emails.
+          </p>
+        </div>
+      </div>
 
     {% endif %}
 


### PR DESCRIPTION
We meant to do this before round 2 but didn’t get to it. We think we need to help people understand that it’s not their own email address needed here if they’ve been forwarded the link.

Content is based on questions the first participant in round 2 of research had with the previous error.

<img width="1088" alt="image" src="https://user-images.githubusercontent.com/355079/178247096-75400519-e899-45f9-a5d6-7a54cb64690b.png">
